### PR TITLE
[WeatherLinkLiveUDP] stanza sentence case bug

### DIFF
--- a/install.py
+++ b/install.py
@@ -15,7 +15,7 @@ class weatherlinkliveudpInstaller(ExtensionInstaller):
             description='Periodically poll weather data from a WeatherLink Live device',
             author="Bastiaan Meelberg",
             config={
-                'weatherlinkliveudp': {
+                'WeatherLinkLiveUDP': {
                     'wll_ip': '1.2.3.4',
                     'poll_interval': 30,
                     'driver': 'user.weatherlinkliveudp'


### PR DESCRIPTION
When I tried to install this on my system (MacOS), it kept giving me a KeyError until I changed the `[weatherlinkliveudp]` stanza to `[WeatherLinkLiveUDP]`, so that it matches the capitalization given in `station_type`. This pull request changes the install.py code so it puts in the correct stanza on install.