### PR TITLE
Corrected barometer readings

### DIFF
--- a/bin/user/weatherlinkliveudp.py
+++ b/bin/user/weatherlinkliveudp.py
@@ -289,7 +289,7 @@ class WWLstation():
 
         if lss_bar_data:
             # most recent bar sensor reading with elevation adjustment **(inches)**
-            packet['altimeter'] = lss_bar_data['bar_sea_level']
+            packet['barometer'] = lss_bar_data['bar_sea_level']
             packet['pressure'] = lss_bar_data['bar_absolute']
 
         if lss_temp_hum_data:


### PR DESCRIPTION
After leaving my station running for a few minutes, I noted the pressure being reported to Davis WeatherLink Cloud was a few mbar off as compared to weewx. It looks like the pressure the Davis console is reporting (bar_sea_level) should properly map to `barometer`, not `altimeter` (even though, confusingly, it does say in the Davis docs that the WeatherLink Live console is using the altimeter method). Making this change causes my weewx data to match what is being reported to WeatherLink Cloud (and my nearby METAR station), so I assume it’s the correct setting.