### PR TITLE
add observation types 

### DIFF
--- a/bin/user/weatherlinkliveudp.py
+++ b/bin/user/weatherlinkliveudp.py
@@ -267,6 +267,11 @@ class WllStation:
             # gust wind direction over last 2 min **(degree)**
             packet['windGustDir'] = iss_data["wind_dir_at_hi_speed_last_2_min"]
 
+            # wind speed and direction average for the last 10 minutes
+            # (not recorded in archive but used elsewhere)
+            packet['windSpeed10'] = iss_data["wind_speed_avg_last_10_min"]
+            packet['windDir10'] = iss_data["wind_dir_scalar_avg_last_10_min"]
+            
             # most recent valid temperature **(F)**
             packet['outTemp'] = iss_data['temp']
 
@@ -281,6 +286,11 @@ class WllStation:
 
             # **(F)**
             packet['windchill'] = iss_data['wind_chill']
+            
+            # **(F)**
+            packet['THSW'] = iss_data['thsw_index']
+            
+            packet['outWetbulb'] = iss_data['wet_bulb']
 
             # most recent solar radiation **(W/m)**
             packet['radiation'] = iss_data['solar_rad']


### PR DESCRIPTION
The WeatherLinkLive device provides more observation types than processed by the driver.

'windSpeed10' and 'windDir10' are defined in WeeWX. They are not saved into the archive, but they were needed for some uploaders. So it would be helpful to include them.

'THSW' is defined in WeeWX, too. Some people prefer it over 'appTemp'. So it would be useful to have that value, too.

Additionally the device provides wet bulb temperature. That is not defined in standard WeeWX, but it can be interesting, too. So I defined 'outWetbulb' and included it, too.